### PR TITLE
Benchmark with different versions of gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache: bundler
 branches:
   only:
     - master
-before_install: gem install bundler -v 1.15.4
+before_install:
+  - gem install bundler -v 1.15.4
+  - gem install haml -v 4.0.7
+  - gem install haml -v 5.0.4
 script:
   - RSPEC_RETRIES=3 VERBOSE=1 bundle exec rake

--- a/lib/benchmark_driver/config.rb
+++ b/lib/benchmark_driver/config.rb
@@ -25,7 +25,6 @@ module BenchmarkDriver
 
   # Subset of FullConfig passed to JobRunner
   Config::RunnerConfig = ::BenchmarkDriver::Struct.new(
-    :executables,   # @param [Array<BenchmarkDriver::Config::Executable>]
     :repeat_count,  # @param [Integer]
     :repeat_result, # @param [String]
     :run_duration,  # @param [Float]

--- a/lib/benchmark_driver/default_job.rb
+++ b/lib/benchmark_driver/default_job.rb
@@ -4,6 +4,7 @@ module BenchmarkDriver
   DefaultJob = ::BenchmarkDriver::Struct.new(
     :name,       # @param [String] name - This is mandatory for all runner
     :metrics,    # @param [Array<BenchmarkDriver::Metric>] - This is mandatory for all runner too, set by job parser.
+    :contexts,   # @param [Array<BenchmarkDriver::Context>] - This is optional parameter for runners.
     :script,     # @param [String] benchmark
     :prelude,    # @param [String,nil] prelude (optional)
     :teardown,   # @param [String,nil] after (optional)
@@ -11,17 +12,17 @@ module BenchmarkDriver
     :required_ruby_version, # @param [String,nil] required_ruby_version (optional)
     defaults: { prelude: '', teardown: '' },
   ) do
-    def runnable_execs(executables)
+    def runnable_contexts(contexts)
       if required_ruby_version
-        executables.select do |executable|
-          Gem::Version.new(executable.version) >= Gem::Version.new(required_ruby_version)
+        contexts.select do |context|
+          Gem::Version.new(context.executable.version) >= Gem::Version.new(required_ruby_version)
         end.tap do |result|
           if result.empty?
             raise "No Ruby executables conforming required_ruby_version (#{required_ruby_version}) are specified"
           end
         end
       else
-        executables
+        contexts
       end
     end
   end

--- a/lib/benchmark_driver/metric.rb
+++ b/lib/benchmark_driver/metric.rb
@@ -24,7 +24,7 @@ module BenchmarkDriver
     :executable,  # @param [BenchmarkDriver::Config::Executable] - Measured Ruby executable
     :gems,        # @param [Hash{ String => String,nil }] - Gem -> version pairs used for the benchmark
     :prelude,     # @param [String,nil] - Context specific setup script (optional)
-    defaults: { gems: {} },
+    defaults: { prelude: '', gems: {} },
   )
 
   # Everything that can be known after running benchmark

--- a/lib/benchmark_driver/output.rb
+++ b/lib/benchmark_driver/output.rb
@@ -8,11 +8,11 @@ module BenchmarkDriver
   #   metrics=
   #   with_warmup
   #     with_job(name:)
-  #       with_context(name:, executable:)
+  #       with_context(name:, executable:, gems:)
   #         report(values:, duration: nil, loop_count: nil, environment: {})
   #   with_benchmark
   #     with_job(name:)
-  #       with_context(name:, executable:)
+  #       with_context(name:, executable:, gems:)
   #         report(values:, duration: nil, loop_count: nil, environment: {})
   class Output
     require 'benchmark_driver/output/compare'
@@ -65,10 +65,9 @@ module BenchmarkDriver
 
     # @param [String] name
     # @param [BenchmarkDriver::Config::Executable] executable
-    # @param [Float] duration
-    # @param [Integer] loop_count
-    def with_context(name:, executable:, &block)
-      context = BenchmarkDriver::Context.new(name: name, executable: executable)
+    # @param [Hash{ String => String}] gems
+    def with_context(name:, executable:, gems: {}, &block)
+      context = BenchmarkDriver::Context.new(name: name, executable: executable, gems: gems)
       @output.with_context(context) do
         block.call
       end

--- a/lib/benchmark_driver/output/simple.rb
+++ b/lib/benchmark_driver/output/simple.rb
@@ -1,5 +1,5 @@
 class BenchmarkDriver::Output::Simple
-  NAME_LENGTH = 8
+  NAME_LENGTH = 10
 
   # @param [Array<BenchmarkDriver::Metric>] metrics
   # @param [Array<BenchmarkDriver::Job>] jobs
@@ -28,7 +28,7 @@ class BenchmarkDriver::Output::Simple
       # Show executable names
       if @context_names.size > 1
         $stdout.print("#{' ' * @name_length}  ")
-        @context_name.each do |context_name|
+        @context_names.each do |context_name|
           $stdout.print("%#{NAME_LENGTH}s  " % context_name)
         end
         $stdout.puts
@@ -36,7 +36,7 @@ class BenchmarkDriver::Output::Simple
 
       block.call
     end
-  rescue
+  ensure
     @with_benchmark = false
   end
 

--- a/lib/benchmark_driver/runner/command_stdout.rb
+++ b/lib/benchmark_driver/runner/command_stdout.rb
@@ -47,9 +47,11 @@ class BenchmarkDriver::Runner::CommandStdout
 
   # @param [BenchmarkDriver::Config::RunnerConfig] config
   # @param [BenchmarkDriver::Output] output
-  def initialize(config:, output:)
+  # @param [BenchmarkDriver::Context] contexts
+  def initialize(config:, output:, contexts:)
     @config = config
     @output = output
+    @contexts = contexts
   end
 
   # This method is dynamically called by `BenchmarkDriver::JobRunner.run`
@@ -60,7 +62,8 @@ class BenchmarkDriver::Runner::CommandStdout
     @output.with_benchmark do
       jobs.each do |job|
         @output.with_job(name: job.name) do
-          @config.executables.each do |exec|
+          @contexts.each do |context|
+            exec = context.executable
             value = BenchmarkDriver::Repeater.with_repeat(config: @config, larger_better: metric.larger_better) do
               stdout = with_chdir(job.working_directory) do
                 with_ruby_prefix(exec) { execute(*exec.command, *job.command) }

--- a/lib/benchmark_driver/runner/memory.rb
+++ b/lib/benchmark_driver/runner/memory.rb
@@ -18,9 +18,11 @@ class BenchmarkDriver::Runner::Memory
 
   # @param [BenchmarkDriver::Config::RunnerConfig] config
   # @param [BenchmarkDriver::Output] output
-  def initialize(config:, output:)
+  # @param [BenchmarkDriver::Context] contexts
+  def initialize(config:, output:, contexts:)
     @config = config
     @output = output
+    @contexts = contexts
   end
 
   # This method is dynamically called by `BenchmarkDriver::JobRunner.run`
@@ -40,11 +42,11 @@ class BenchmarkDriver::Runner::Memory
     @output.with_benchmark do
       jobs.each do |job|
         @output.with_job(name: job.name) do
-          job.runnable_execs(@config.executables).each do |exec|
+          job.runnable_contexts(@contexts).each do |context|
             value = BenchmarkDriver::Repeater.with_repeat(config: @config, larger_better: false) do
-              run_benchmark(job, exec: exec)
+              run_benchmark(job, context: context)
             end
-            @output.with_context(name: exec.name, executable: exec) do
+            @output.with_context(name: context.name, executable: context.executable, gems: context.gems) do
               @output.report(values: { METRIC => value }, loop_count: job.loop_count)
             end
           end
@@ -56,18 +58,18 @@ class BenchmarkDriver::Runner::Memory
   private
 
   # @param [BenchmarkDriver::Runner::Ips::Job] job - loop_count is not nil
-  # @param [BenchmarkDriver::Config::Executable] exec
+  # @param [BenchmarkDriver::Context] context
   # @return [BenchmarkDriver::Metrics]
-  def run_benchmark(job, exec:)
+  def run_benchmark(job, context:)
     benchmark = BenchmarkScript.new(
-      prelude:    job.prelude,
+      prelude:    "#{context.prelude}\n#{job.prelude}",
       script:     job.script,
       teardown:   job.teardown,
       loop_count: job.loop_count,
     )
 
     output = with_script(benchmark.render) do |path|
-      execute('/usr/bin/time', *exec.command, path)
+      execute('/usr/bin/time', *context.executable.command, path)
     end
 
     match_data = /^(?<user>\d+.\d+)user\s+(?<system>\d+.\d+)system\s+(?<elapsed1>\d+):(?<elapsed2>\d+.\d+)elapsed.+\([^\s]+\s+(?<maxresident>\d+)maxresident\)k$/.match(output)

--- a/lib/benchmark_driver/runner/recorded.rb
+++ b/lib/benchmark_driver/runner/recorded.rb
@@ -30,9 +30,11 @@ class BenchmarkDriver::Runner::Recorded
 
   # @param [BenchmarkDriver::Config::RunnerConfig] config
   # @param [BenchmarkDriver::Output] output
-  def initialize(config:, output:)
+  # @param [BenchmarkDriver::Context] contexts
+  def initialize(config:, output:, contexts:)
     @config = config
     @output = output
+    @contexts = contexts
   end
 
   # This method is dynamically called by `BenchmarkDriver::JobRunner.run`
@@ -48,7 +50,7 @@ class BenchmarkDriver::Runner::Recorded
       records.each do |record|
         @output.with_job(name: record.name) do
           record.benchmark_results.each do |context, result|
-            @output.with_context(name: context.name, executable: context.executable) do
+            @output.with_context(name: context.name, executable: context.executable, gems: context.gems) do
               @output.report(
                 values: result.values,
                 duration: result.duration,

--- a/lib/benchmark_driver/runner/ruby_stdout.rb
+++ b/lib/benchmark_driver/runner/ruby_stdout.rb
@@ -64,9 +64,11 @@ class BenchmarkDriver::Runner::RubyStdout
 
   # @param [BenchmarkDriver::Config::RunnerConfig] config
   # @param [BenchmarkDriver::Output] output
-  def initialize(config:, output:)
+  # @param [BenchmarkDriver::Context] contexts
+  def initialize(config:, output:, contexts:)
     @config = config
     @output = output
+    @contexts = contexts
   end
 
   # This method is dynamically called by `BenchmarkDriver::JobRunner.run`
@@ -77,7 +79,8 @@ class BenchmarkDriver::Runner::RubyStdout
     @output.with_benchmark do
       jobs.each do |job|
         @output.with_job(name: job.name) do
-          @config.executables.each do |exec|
+          @contexts.each do |context|
+            exec = context.executable
             repeat_params = { config: @config, larger_better: metric.larger_better }
             value, environment = BenchmarkDriver::Repeater.with_repeat(repeat_params) do
               stdout = with_chdir(job.working_directory) do

--- a/spec/fixtures/haml/template.haml
+++ b/spec/fixtures/haml/template.haml
@@ -1,0 +1,18 @@
+!!! html
+
+%html
+  %head
+    %title Simple Benchmark
+  %body
+    %h1= header
+    - unless item.empty?
+      %ul
+        - for i in item
+          - if i[:current]
+            %li
+              %strong= i[:name]
+          - else
+            %li
+              %a{:href => i[:url]}= i[:name]
+    - else
+      %p The list is empty.

--- a/spec/fixtures/yaml/haml_render.yml
+++ b/spec/fixtures/yaml/haml_render.yml
@@ -1,0 +1,19 @@
+contexts:
+  - gems: { haml: 4.0.7 }
+    prelude: |
+      options = { escape_html: true, format: :html5, ugly: true }
+  - gems: { haml: 5.0.4 }
+    prelude: |
+      options = { escape_html: true, format: :html5 }
+      Haml::Options.buffer_defaults.merge!(escape_html: true)
+prelude: |
+  view = Struct.new(:header, :item).new
+  view.header = 'Colors'
+  view.item = [
+    { name: 'red',   current: true,  url: '#red'   },
+    { name: 'green', current: false, url: '#green' },
+    { name: 'blue',  current: false, url: '#blue'  },
+  ]
+  haml = File.read('spec/fixtures/haml/template.haml')
+  Haml::Engine.new(haml, options).def_method(view, :run_haml)
+benchmark: view.render

--- a/spec/fixtures/yaml/haml_render.yml
+++ b/spec/fixtures/yaml/haml_render.yml
@@ -15,5 +15,6 @@ prelude: |
     { name: 'blue',  current: false, url: '#blue'  },
   ]
   haml = File.read('spec/fixtures/haml/template.haml')
-  Haml::Engine.new(haml, options).def_method(view, :run_haml)
+  Haml::Engine.new(haml, options).def_method(view, :render)
 benchmark: view.render
+loop_count: 1000


### PR DESCRIPTION
## Benchmark definition

```rb
$ cat haml_render.yml
contexts:
  - gems: { haml: 4.0.7 }
    prelude: |
      options = { escape_html: true, format: :html5, ugly: true }
  - gems: { haml: 5.0.4 }
    prelude: |
      options = { escape_html: true, format: :html5 }
      Haml::Options.buffer_defaults.merge!(escape_html: true)
prelude: |
  view = Struct.new(:header, :item).new
  view.header = 'Colors'
  view.item = [
    { name: 'red',   current: true,  url: '#red'   },
    { name: 'green', current: false, url: '#green' },
    { name: 'blue',  current: false, url: '#blue'  },
  ]
  haml = File.read('spec/fixtures/haml/template.haml')
  Haml::Engine.new(haml, options).def_method(view, :render)
benchmark: view.render
loop_count: 100000
```

## Result
```
$ exe/benchmark-driver haml_render.yml
Calculating -------------------------------------
                     haml 4.0.7  haml 5.0.4
         view.render    59.854k    256.455k i/s -    100.000k times in 1.670743s 0.389932s

Comparison:
                      view.render
          haml 5.0.4:    256455.1 i/s
          haml 4.0.7:     59853.6 i/s - 4.28x  slower
```