### PR TITLE
Fix undefined method `[]' in BulkOutput#report

### DIFF
--- a/lib/benchmark_driver/bulk_output.rb
+++ b/lib/benchmark_driver/bulk_output.rb
@@ -51,7 +51,9 @@ module BenchmarkDriver
 
     # @param [BenchmarkDriver::Result] result
     def report(result)
-      @job_context_result[@job][@context] = result
+      if defined?(@job_context_result)
+        @job_context_result[@job][@context] = result
+      end
     end
   end
 end


### PR DESCRIPTION
when running the warm up, @job_context_result is not defined
to we should check this before assigning the results.

This is similar to what is done in BenchmarkDriver::Output::Compare#report

fix #40