### PR TITLE
Do not create executables if they already exist

### DIFF
--- a/lib/benchmark_driver/runner.rb
+++ b/lib/benchmark_driver/runner.rb
@@ -54,6 +54,11 @@ module BenchmarkDriver
         }
       end
 
+      with_executables, without_executables = contexts.partition { |context| context.name && context.executable }
+      with_executables + build_contexts_with_executables(without_executables, executables)
+    end
+
+    def build_contexts_with_executables(contexts, executables)
       # Create direct product of contexts
       contexts.product(executables).map do |context, executable|
         name = context.name


### PR DESCRIPTION
When the context already has an executable and name,
there is no need to create it again.

This caused that contexts where missing in a recorded run
when it gets executed on a machine without these rubies installed.

Fix #43