### PR TITLE
remove warnings

### DIFF
--- a/lib/benchmark_driver/output/compare.rb
+++ b/lib/benchmark_driver/output/compare.rb
@@ -61,7 +61,7 @@ class BenchmarkDriver::Output::Compare
     loop_count = @job_results.first.loop_count
     if loop_count && @job_results.all? { |r| r.loop_count == loop_count }
       $stdout.print(" - #{humanize(loop_count)} times")
-      if @job_results.all? { |result| !result.duration.nil? }
+      if @job_results.all? { |job_result| !job_result.duration.nil? }
         $stdout.print(" in")
         show_durations
       end

--- a/lib/benchmark_driver/output/record.rb
+++ b/lib/benchmark_driver/output/record.rb
@@ -51,7 +51,7 @@ class BenchmarkDriver::Output::Record
   private
 
   def save_record
-    jobs = @benchmark_metrics
+    # jobs = @benchmark_metrics
     yaml = {
       'type' => 'recorded',
       'job_warmup_context_result' => @job_warmup_context_result,

--- a/lib/benchmark_driver/runner/ips.rb
+++ b/lib/benchmark_driver/runner/ips.rb
@@ -144,7 +144,7 @@ class BenchmarkDriver::Runner::Ips
   end
 
   def execute(*args)
-    stdout = IO.popen(args, &:read) # TODO: print stdout if verbose=2
+    IO.popen(args, &:read) # TODO: print stdout if verbose=2
     unless $?.success?
       raise "Failed to execute: #{args.shelljoin} (status: #{$?.exitstatus})"
     end

--- a/lib/benchmark_driver/runner/ruby_stdout.rb
+++ b/lib/benchmark_driver/runner/ruby_stdout.rb
@@ -131,7 +131,7 @@ class BenchmarkDriver::Runner::RubyStdout
 
   StdoutToMetrics = ::BenchmarkDriver::Struct.new(:stdout, :value_from_stdout, :environment_from_stdout) do
     def value
-      value = eval(value_from_stdout, binding)
+      eval(value_from_stdout, binding)
     end
 
     def environment


### PR DESCRIPTION
These trivial fixes to remove warnings when running Ruby with -w (`ruby -w`).