### PR TITLE
Fixed ZeroDivisionError in warming up for slow task(> 100ms)

### DIFF
--- a/lib/benchmark_driver/runner/ips.rb
+++ b/lib/benchmark_driver/runner/ips.rb
@@ -168,7 +168,7 @@ end
 __bmdv_after = Time.now
 
 # second warmup
-__bmdv_ip100ms = (__bmdv_i.to_f / (__bmdv_after - __bmdv_before) / 10.0).floor
+__bmdv_ip100ms = (__bmdv_i.to_f / (__bmdv_after - __bmdv_before) / 10.0).ceil
 __bmdv_loops = 0
 __bmdv_duration = 0.0
 __bmdv_target = Time.now + #{second_warmup_duration}


### PR DESCRIPTION
fixes #31

```ruby
require 'benchmark_driver'
Benchmark.driver do |x|
  x.report 'sleep 0.08', 'sleep 0.08'
  x.report 'sleep 0.12', 'sleep 0.12'
end
# Warming up --------------------------------------
#           sleep 0.08     12.051 i/s -      13.000 times in 1.078761s (82.98ms/i)
#           sleep 0.12      0.000 i/s -       ERROR times in 0.323725sZeroDivisionError: divided by 0
```

```ruby
__bmdv_ip100ms = 0 # if the first warming up is slower than 100ms/i

while Time.now < __bmdv_target
  __bmdv_i = 0
  __bmdv_before = Time.now
  while __bmdv_i < __bmdv_ip100ms # always false
    #{script} # never executed
    __bmdv_i += 1
  end
  __bmdv_after = Time.now

  # __bmdv_loops will always be zero
  __bmdv_loops += __bmdv_i
  # meaningless duration because "#{script}" is not executed
  __bmdv_duration += (__bmdv_after - __bmdv_before)
end
```

```ruby
# other possible way to fix this
__bmdv_ip100ms = (__bmdv_i.to_f / (__bmdv_after - __bmdv_before) / 10.0).floor
__bmdv_ip100ms = 1 if __bmdv_ip100ms.zero?
```
