### PR TITLE
Fix description of memory runner [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ ips, time, memory, once
 |:-------|:------------|
 | ips | Iteration per second (default) |
 | time | Elapsed seconds |
-| memory | Max resident set. This is supported only on Linux for now. |
+| memory | Max resident set. This is supported only on Linux and macOS for now. |
 | once | Forces `loop_count` to 1 for testing |
 | ruby\_stdout | Special runner to integrate existing benchmarks |
 


### PR DESCRIPTION
Since #53, memory runner supported macOS too.