### PR TITLE
Remove an extra space from markdown output value

### DIFF
--- a/lib/benchmark_driver/output/markdown.rb
+++ b/lib/benchmark_driver/output/markdown.rb
@@ -83,15 +83,15 @@ class BenchmarkDriver::Output::Markdown
 
   def humanize(value)
     if BenchmarkDriver::Result::ERROR.equal?(value)
-      return " %#{NAME_LENGTH}s" % 'ERROR'
+      return "%#{NAME_LENGTH}s" % 'ERROR'
     elsif value == 0.0
-      return " %#{NAME_LENGTH}.3f" % 0.0
+      return "%#{NAME_LENGTH}.3f" % 0.0
     elsif value < 0
       raise ArgumentError.new("Negative value: #{value.inspect}")
     end
 
     scale = (Math.log10(value) / 3).to_i
-    prefix = "%#{NAME_LENGTH}.3f" % (value.to_f / (1000 ** scale))
+    prefix = "%#{NAME_LENGTH - 1}.3f" % (value.to_f / (1000 ** scale))
     suffix =
       case scale
       when 1; 'k'


### PR DESCRIPTION
Before:

    # Execution time (s)

    |                 |   2.7.0|
    |:----------------|:-------|
    |split: CP932     |    0.481|
    |split: UTF-8     |    1.255|
    |3.0.1: CP932     |    1.615|
    |3.0.1: UTF-8     |    2.471|
    |master: CP932    |    2.586|
    |master: UTF-8    |    3.390|
    |optimize: CP932  |    1.062|
    |optimize: UTF-8  |    1.868|
    |Arrow: UTF-8     |    0.236|

After:

    # Execution time (s)

    |                 |   2.7.0|
    |:----------------|:-------|
    |split: CP932     |   0.491|
    |split: UTF-8     |   1.241|
    |3.0.1: CP932     |   1.631|
    |3.0.1: UTF-8     |   2.407|
    |master: CP932    |   2.595|
    |master: UTF-8    |   3.373|
    |optimize: CP932  |   1.074|
    |optimize: UTF-8  |   1.877|
    |Arrow: UTF-8     |   0.235|

with the following configurations:

  * https://gitlab.com/ktou/rabbit-slide-kou-rubykaigi-2019/blob/36184a2ffe5827999d00bb991300b18a933ef9dd/benchmark.yaml
  * https://gitlab.com/ktou/rabbit-slide-kou-rubykaigi-2019/blob/36184a2ffe5827999d00bb991300b18a933ef9dd/Rakefile#L25-32