### PR TITLE
Don't divide by zero when benchmarks error

### DIFF
--- a/lib/benchmark_driver/output/compare.rb
+++ b/lib/benchmark_driver/output/compare.rb
@@ -181,6 +181,17 @@ class BenchmarkDriver::Output::Compare
     end
   end
 
+  def show_slower(better_result, worse_result)
+    top = worse_result.value
+    bottom = better_result.value
+    top, bottom = bottom, top if @metrics.first.larger_better
+
+    unless BenchmarkDriver::Result::ERROR.equal?(bottom)
+      ratio = top / bottom
+      "- %.2fx  #{@metrics.first.worse_word}" % ratio
+    end
+  end
+
   # @param [Array<BenchmarkDriver::Output::Compare::Result>] results
   # @param [TrueClass,FalseClass] show_context
   def show_results(results, show_context:)
@@ -194,14 +205,7 @@ class BenchmarkDriver::Output::Compare
 
     first = results.first
     results.each do |result|
-      if result != first
-        if @metrics.first.larger_better
-          ratio = (first.value / result.value)
-        else
-          ratio = (result.value / first.value)
-        end
-        slower = "- %.2fx  #{@metrics.first.worse_word}" % ratio
-      end
+      slower = show_slower(first, result) if result != first
       if show_context
         name = result.context.name
       else

--- a/spec/fixtures/extra/full_fail.yml
+++ b/spec/fixtures/extra/full_fail.yml
@@ -1,0 +1,4 @@
+benchmark:
+  one: raise
+  two: raise
+loop_count: 1

--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -15,6 +15,16 @@ describe 'YAML interface' do
     end
   end
 
+  it 'exits normally when benchmarks raise' do
+    begin
+      orig = $stderr
+      $stderr = StringIO.new
+      benchmark_driver fixture_extra('full_fail.yml'), '-v'
+    ensure
+      $stderr = orig
+    end
+  end
+
   it 'runs --output=all' do
     benchmark_driver File.expand_path('./fixtures/yaml/example_multi.yml', __dir__), '--output=all', '--run-duration=0.2'
   end


### PR DESCRIPTION
Running the following benchmark used to print a long
stack trace due to zero division.

```yaml
benchmark:
  one: raise
  two: raise
loop_count: 1
```

Fix it by checking for `BenchmarkDriver::Result::ERROR`.

PS: I ran into this while trying to run https://github.com/ruby/ruby/blob/master/benchmark/vm2_fiber_allocate.yml. The benchmark raises on my system since it allocates too many pages.