### PR TITLE
Allow defining output options for plugin

### DIFF
--- a/exe/benchmark-driver
+++ b/exe/benchmark-driver
@@ -20,6 +20,19 @@ config = BenchmarkDriver::Config.new.tap do |c|
     end
     o.on('-o', '--output TYPE', String, 'Specify output type: compare, simple, markdown, record (default: compare)') do |out|
       c.output_type = out
+      begin
+        plugin_options = BenchmarkDriver::Output.get(out).const_get('OPTIONS', false)
+      rescue ArgumentError, LoadError, NameError
+      else
+        plugin_options.each do |name, args|
+          unless args.first.start_with?('--output-')
+            raise ArgumentError.new("#{args.first.dump} must start with '--output-'")
+          end
+          o.on(*args) do |opt|
+            c.output_opts[name] = opt
+          end
+        end
+      end
     end
     o.on('-e', '--executables EXECS', String, 'Ruby executables (e1::path1 arg1; e2::path2 arg2;...)') do |e|
       e.split(';').each do |name_path|

--- a/lib/benchmark_driver/config.rb
+++ b/lib/benchmark_driver/config.rb
@@ -6,6 +6,7 @@ module BenchmarkDriver
   Config = ::BenchmarkDriver::Struct.new(
     :runner_type,   # @param [String]
     :output_type,   # @param [String]
+    :output_opts,   # @param [Hash{ Symbol => Object }]
     :paths,         # @param [Array<String>]
     :executables,   # @param [Array<BenchmarkDriver::Config::Executable>]
     :filters,       # @param [Array<Regexp>]
@@ -17,6 +18,7 @@ module BenchmarkDriver
     defaults: {
       runner_type: 'ips',
       output_type: 'compare',
+      output_opts: {},
       filters: [],
       repeat_count: 1,
       repeat_result: 'best',

--- a/lib/benchmark_driver/output.rb
+++ b/lib/benchmark_driver/output.rb
@@ -38,11 +38,24 @@ module BenchmarkDriver
     # @param [Array<BenchmarkDriver::Metric>] metrics
     # @param [Array<BenchmarkDriver::Job>] jobs
     # @param [Array<BenchmarkDriver::Context>] contexts
-    def initialize(type:, metrics:, jobs:, contexts:)
-      @output = ::BenchmarkDriver::Output.get(type).new(
+    # @param [Hash{ Symbol => Object }] options
+    def initialize(type:, metrics:, jobs:, contexts:, options:)
+      output = ::BenchmarkDriver::Output.get(type)
+      output_params = output.instance_method(:initialize).parameters.select do |type, _name|
+        type == :keyreq || type == :key
+      end.map(&:last)
+
+      # Optionally pass `options` to #initialize
+      kwargs = {}
+      if output_params.include?(:options)
+        kwargs[:options] = options
+      end
+
+      @output = output.new(
         metrics: metrics,
         jobs: jobs,
         contexts: contexts,
+        **kwargs,
       )
     end
 

--- a/lib/benchmark_driver/output.rb
+++ b/lib/benchmark_driver/output.rb
@@ -20,6 +20,17 @@ module BenchmarkDriver
     require 'benchmark_driver/output/record'
     require 'benchmark_driver/output/simple'
 
+    # @param [String] type
+    def self.get(type)
+      if type.include?(':')
+        raise ArgumentError.new("Output type '#{type}' cannot contain ':'")
+      end
+
+      require "benchmark_driver/output/#{type}" # for plugin
+      camelized = type.split('_').map(&:capitalize).join
+      ::BenchmarkDriver::Output.const_get(camelized, false)
+    end
+
     # BenchmarkDriver::Output is pluggable.
     # Create `BenchmarkDriver::Output::Foo` as benchmark_dirver-output-foo.gem and specify `-o foo`.
     #
@@ -28,14 +39,7 @@ module BenchmarkDriver
     # @param [Array<BenchmarkDriver::Job>] jobs
     # @param [Array<BenchmarkDriver::Context>] contexts
     def initialize(type:, metrics:, jobs:, contexts:)
-      if type.include?(':')
-        raise ArgumentError.new("Output type '#{type}' cannot contain ':'")
-      end
-
-      require "benchmark_driver/output/#{type}" # for plugin
-      camelized = type.split('_').map(&:capitalize).join
-
-      @output = ::BenchmarkDriver::Output.const_get(camelized, false).new(
+      @output = ::BenchmarkDriver::Output.get(type).new(
         metrics: metrics,
         jobs: jobs,
         contexts: contexts,

--- a/lib/benchmark_driver/output/all.rb
+++ b/lib/benchmark_driver/output/all.rb
@@ -2,14 +2,19 @@ class BenchmarkDriver::Output::All
   NAME_LENGTH = 20
   CONTEXT_LENGTH = 20
 
+  OPTIONS = {
+    sort: ['--output-sort true|false', TrueClass, 'Sort all output or not (default: true)'],
+  }
+
   # @param [Array<BenchmarkDriver::Metric>] metrics
   # @param [Array<BenchmarkDriver::Job>] jobs
   # @param [Array<BenchmarkDriver::Context>] contexts
-  def initialize(metrics:, jobs:, contexts:)
+  def initialize(metrics:, jobs:, contexts:, options:)
     @metrics = metrics
     @job_names = jobs.map(&:name)
     @context_names = contexts.map(&:name)
     @name_length = [@job_names.map(&:length).max, NAME_LENGTH].max
+    @sort = options.fetch(:sort, true)
   end
 
   def with_warmup(&block)
@@ -67,7 +72,10 @@ class BenchmarkDriver::Output::All
     else
       print("\e[#{num_values}F")
     end
-    @context_values[@context] = result.all_values.values.first.sort
+    @context_values[@context] = result.all_values.values.first
+    if @sort
+      @context_values[@context] = @context_values[@context].sort
+    end
 
     precision = result.values.values.first.to_s.sub(/\A\d+\./, '').length
     num_values.times do |i|

--- a/lib/benchmark_driver/runner.rb
+++ b/lib/benchmark_driver/runner.rb
@@ -36,6 +36,7 @@ module BenchmarkDriver
               metrics: metrics,
               jobs: klass_jobs.map { |job| BenchmarkDriver::Job.new(name: job.name) },
               contexts: contexts,
+              options: config.output_opts,
             )
             with_clean_env do
               runner.new(config: runner_config, output: output, contexts: contexts).run(klass_jobs)

--- a/spec/yaml_spec.rb
+++ b/spec/yaml_spec.rb
@@ -48,4 +48,9 @@ describe 'YAML interface' do
   it 'runs --output=all' do
     benchmark_driver File.expand_path('./fixtures/yaml/example_multi.yml', __dir__), '--output=all', '--run-duration=0.2'
   end
+
+  it 'accepts output options' do
+    benchmark_driver File.expand_path('./fixtures/yaml/example_multi.yml', __dir__),
+      '--output=all', '--output-sort=false', '--run-duration=0.2'
+  end
 end


### PR DESCRIPTION
## Plugin interface
Now output plugins can _optionally_ have:

```diff
class BenchmarkDriver::Output::All
+  OPTIONS = {
+    sort: ['--output-sort true|false', TrueClass, 'Sort all output or not (default: true)'],
+  }

-  def initialize(metrics:, jobs:, contexts:)
+  def initialize(metrics:, jobs:, contexts:, options:)
```

If there's no `options` option, it also continues to work and it's backward compatible.

## Usage
In CLI, we can dynamically define option like (`--output-sort` for `all` output appears only when `--output=all` is passed before `--help`):

```
$ benchmark-driver --output=all --help
Usage: benchmark-driver [options] RUBY|YAML...
    -r, --runner TYPE                Specify runner type: ips, time, memory, once, block (default: ips)
    -o, --output TYPE                Specify output type: compare, simple, markdown, record (default: compare)
    -e, --executables EXECS          Ruby executables (e1::path1 arg1; e2::path2 arg2;...)
        --rbenv VERSIONS             Ruby executables in rbenv (x.x.x arg1;y.y.y arg2;...)
        --repeat-count NUM           Try benchmark NUM times and use the fastest result or the worst memory usage
        --repeat-result TYPE         Yield "best", "average" or "worst" result with --repeat-count (default: best)
        --bundler                    Install and use gems specified in Gemfile
        --filter REGEXP              Filter out benchmarks with given regexp
        --run-duration SECONDS       Warmup estimates loop_count to run for this duration (default: 3)
        --timeout SECONDS            Timeout ruby command execution with timeout(1)
    -v, --verbose                    Verbose mode. Multiple -v options increase visilibity (max: 2)
        --output-sort true|false     Sort all output or not (default: true)
```

and this can be used like:

```
$ benchmark-driver --output=all --output-sort=false benchmark.yml --repeat-count=4
Calculating -------------------------------------
Optcarrot Lan_Master.nes   54.055783173785407 fps
                           54.076238306288154
                           53.751763156428240
                           52.543979841749298
```