### PR TITLE
Hide stderr messages

### DIFF
--- a/exe/benchmark-driver
+++ b/exe/benchmark-driver
@@ -47,7 +47,7 @@ config = BenchmarkDriver::Config.new.tap do |c|
       r.split(';').each do |version|
         executables << BenchmarkDriver::Rbenv.parse_spec(version)
       end
-    end if system("which rbenv > #{File::NULL}")
+    end if system("which rbenv > #{File::NULL} 2>&1")
     o.on('--ridkuse VERSIONS', String, 'Ruby executables in ridk use (x.x.x arg1;y.y.y arg2;...) for RubyInstaller2 on Windows') do |r|
       r.split(';').each do |version|
         executables << BenchmarkDriver::RidkUse.parse_spec(version)


### PR DESCRIPTION
This patch hide stderr message of rbenv option on Windows.

I got this message.
```
>benchmark-driver -h
'which' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
Usage: benchmark-driver [options] RUBY|YAML...
    -r, --runner TYPE                Specify runner type: ips, time, memory, once, block (default: ips)
    -o, --output TYPE                Specify output type: compare, simple, markdown, record (default: compare)
    -e, --executables EXECS          Ruby executables (e1::path1 arg1; e2::path2 arg2;...)
        --ridkuse VERSIONS           Ruby executables in ridk use (x.x.x arg1;y.y.y arg2;...) for RubyInstaller2 on Windows
        --repeat-count NUM           Try benchmark NUM times and use the fastest result or the worst memory usage
        --repeat-result TYPE         Yield "best", "average" or "worst" result with --repeat-count (default: best)
        --bundler                    Install and use gems specified in Gemfile
        --filter REGEXP              Filter out benchmarks with given regexp
        --run-duration SECONDS       Warmup estimates loop_count to run for this duration (default: 3)
    -v, --verbose                    Verbose mode. Multiple -v options increase visilibity (max: 2)
```
