### PR TITLE
New repeat result type "median"

### DIFF
--- a/spec/benchmark_driver_spec.rb
+++ b/spec/benchmark_driver_spec.rb
@@ -47,6 +47,11 @@ describe 'benchmark-driver command' do
       '--repeat-count', '2', '--repeat-result', 'average'
   end
 
+  it 'returns median result with repeats' do
+    benchmark_driver fixture_yaml('blank_hash.yml'), '-r', 'ips', '-o', 'compare', '--run-duration', '0.1',
+      '--repeat-count', '2', '--repeat-result', 'median'
+  end
+
   it 'runs a Ruby script as single-execution benchmark' do
     benchmark_driver fixture_extra('single.rb'), '-v'
   end


### PR DESCRIPTION
Often, the slowest benchmark result is due to random IOs.  The fastest benchmark result tends to be a result of different P-state.  We don't want to take them into account.  In order to achieve this property a new result type called "median" is introduced in this pull request.  It ignores anything but the median value of the result array.