### PR TITLE
negative duration is an error

### DIFF
--- a/lib/benchmark_driver/runner/ips.rb
+++ b/lib/benchmark_driver/runner/ips.rb
@@ -108,8 +108,8 @@ class BenchmarkDriver::Runner::Ips
     duration = Tempfile.open(['benchmark_driver-', '.rb']) do |f|
       with_script(benchmark.render(result: f.path)) do |path|
         IO.popen([*context.executable.command, path], &:read) # TODO: print stdout if verbose=2
-        if $?.success?
-          Float(f.read)
+        if $?.success? && ((value = Float(f.read)) > 0)
+          value
         else
           BenchmarkDriver::Result::ERROR
         end

--- a/lib/benchmark_driver/runner/once.rb
+++ b/lib/benchmark_driver/runner/once.rb
@@ -66,8 +66,8 @@ class BenchmarkDriver::Runner::Once
     Tempfile.open(['benchmark_driver-', '.rb']) do |f|
       with_script(benchmark.render(result: f.path)) do |path|
         IO.popen([*context.executable.command, path], &:read) # TODO: print stdout if verbose=2
-        if $?.success?
-          Float(f.read)
+        if $?.success? && ((value = Float(f.read)) > 0)
+          value
         else
           BenchmarkDriver::Result::ERROR
         end


### PR DESCRIPTION
display an error instead of an exception, fixes: https://github.com/benchmark-driver/benchmark-driver/issues/63

shorttest     ERROR      ERROR       ERROR i/s -     10.000k times in 0.000000s 0.000000s 0.000000s