### PR TITLE
Improve detection of whether Struct.new(keyword_init: true) is supported

### DIFF
--- a/lib/benchmark_driver/struct.rb
+++ b/lib/benchmark_driver/struct.rb
@@ -5,8 +5,8 @@
 module BenchmarkDriver
   class ::Struct
     SUPPORT_KEYWORD_P = begin
-                          ::Struct.new(:a, keyword_init: true)
-                          true
+                          s = ::Struct.new(:a, keyword_init: true)
+                          s.new(a: 1).a == 1
                         rescue TypeError
                           false
                         end


### PR DESCRIPTION
* The previous check would return true on TruffleRuby 19.3.0, even though
  that version does not support it correctly (it returns `{:a=>1}` instead
  of `1` for `Struct.new(:a, keyword_init: true).new(a: 1).a`).

FWIW, TruffleRuby master supports `Struct.new(keyword_init: true)` correctly.