### PR TITLE
[WIP] Prototype for top-level DSL and supporting `benchmark-driver mybench.rb`

### DIFF
--- a/exe/benchmark-driver
+++ b/exe/benchmark-driver
@@ -89,7 +89,7 @@ config = BenchmarkDriver::Config.new.tap do |c|
     abort e.message
   end
   if c.paths.empty?
-    abort "No YAML file is specified!\n\n#{parser.help}"
+    abort "No YAML or Ruby benchmark is specified!\n\n#{parser.help}"
   end
 
   # Configs that need to be set lazily
@@ -114,10 +114,18 @@ jobs = config.paths.flat_map do |path|
 
   # Treat *.rb as a single-execution benchmark, others are considered as YAML definition
   if path.end_with?('.rb')
-    name = File.basename(path).sub(/\.rb\z/, '')
+    name = File.basename(path, '.rb')
     script = File.read(path)
-    prelude = script.slice!(/\A(^#[^\n]+\n)+/m) || '' # preserve magic comment
-    job.merge!('prelude' => prelude, 'benchmark' => { name => script }, 'loop_count' => 1)
+    if script =~ /\bBenchmark\.driver\b/
+      # raise 'Benchmark.driver DSL benchmarks currently need to be run with `ruby benchmark.rb`'
+      job.merge!(BenchmarkDriver::RubyInterface.load(path))
+    elsif script =~ /^\s*prelude\b/
+      job.merge!(BenchmarkDriver::RubyTopLevelDSL.load(path))
+    else
+      # single-execution benchmark
+      prelude = script.slice!(/\A(^#[^\n]+\n)+/m) || '' # preserve magic comment
+      job.merge!('prelude' => prelude, 'benchmark' => { name => script }, 'loop_count' => 1)
+    end
   else
     job.merge!(YAML.load_file(path))
   end

--- a/lib/benchmark_driver.rb
+++ b/lib/benchmark_driver.rb
@@ -7,6 +7,7 @@ require 'benchmark_driver/rvm'
 require 'benchmark_driver/repeater'
 require 'benchmark_driver/ridkuse'
 require 'benchmark_driver/ruby_interface'
+require 'benchmark_driver/ruby_toplevel_dsl'
 require 'benchmark_driver/runner'
 require 'benchmark_driver/version'
 

--- a/lib/benchmark_driver/ruby_interface.rb
+++ b/lib/benchmark_driver/ruby_interface.rb
@@ -10,7 +10,7 @@ module BenchmarkDriver
         @config.executables = @executables
       end
 
-      jobs = @jobs.flat_map do |job|
+      jobs = @jobs.map do |job|
         BenchmarkDriver::JobParser.parse({
           type: @config.runner_type,
           prelude: @prelude,

--- a/lib/benchmark_driver/ruby_toplevel_dsl.rb
+++ b/lib/benchmark_driver/ruby_toplevel_dsl.rb
@@ -1,0 +1,49 @@
+module BenchmarkDriver
+  class RubyTopLevelDSL
+    module DSL
+      private
+
+      def prelude(script)
+        INSTANCE.prelude(script)
+      end
+
+      def report(name, script = name)
+        INSTANCE.report(name, script)
+      end
+    end
+
+    def self.load(path)
+      MAIN_OBJECT.extend(DSL)
+      Kernel.load path
+      INSTANCE.build_config
+    end
+
+    def initialize
+      @prelude = ''
+      @jobs = {}
+    end
+
+    def build_config
+      {
+        prelude: @prelude,
+        benchmark: @jobs
+      }
+    end
+
+    # @param [String] script
+    def prelude(script)
+      @prelude << "#{script}\n"
+    end
+
+    # @param [String] name - Name shown on result output.
+    # @param [String,nil] script - Benchmarked script in String. If nil, name is considered as script too.
+    def report(name, script = name)
+      # @jobs << { benchmark: [{ name: name, script: script }] }
+      @jobs[name] = script
+    end
+
+    INSTANCE = new
+  end
+end
+
+BenchmarkDriver::RubyTopLevelDSL::MAIN_OBJECT = self


### PR DESCRIPTION
A prototype for the top-level DSL as mentioned in https://github.com/benchmark-driver/benchmark-driver/issues/67#issuecomment-615980651

This makes all variants of `app_fib` in https://github.com/eregon/ruby/commit/964ab520ef092cae69d2891b019e8fa0e4813936 work with
`benchmark-driver file.rb/yml`:
```
$ benchmark-driver benchmark/app_fib2.rb
Warming up --------------------------------------
             app_fib      4.038 i/s -       5.000 times in 1.238384s (247.68ms/i)
Calculating -------------------------------------
             app_fib      4.027 i/s -      12.000 times in 2.979929s (248.33ms/i)

$ benchmark-driver benchmark/app_fib3.rb
Warming up --------------------------------------
             app_fib      3.979 i/s -       4.000 times in 1.005206s (251.30ms/i)
Calculating -------------------------------------
             app_fib      4.043 i/s -      11.000 times in 2.720868s (247.35ms/i)

$ benchmark-driver benchmark/app_fib.yml 
Warming up --------------------------------------
             app_fib      4.010 i/s -       5.000 times in 1.246770s (249.35ms/i)
Calculating -------------------------------------
             app_fib      4.025 i/s -      12.000 times in 2.981339s (248.44ms/i)


```
The original [benchmark/app_fib.rb](https://github.com/eregon/ruby/blob/top-level-dsl/benchmark/app_fib.rb) has no warmup as before (behavior unchanged):
```
$ benchmark-driver benchmark/app_fib.rb 
Calculating -------------------------------------
             app_fib      4.014 i/s -       1.000 times in 0.249122s (249.12ms/i)
```

@k0kubun What do you think, is that close to what you had in mind for the top-level DSL?