### PR TITLE
Fix broken output on `-o markdown --output-compare`

### DIFF
--- a/lib/benchmark_driver/output/markdown.rb
+++ b/lib/benchmark_driver/output/markdown.rb
@@ -133,13 +133,9 @@ class BenchmarkDriver::Output::Markdown
       if context == worst
         result = '-'
       else
-        result = result.values.first[1]
-        if order == :min_by
-          result = result.fdiv(worst_result)
-        else
-          result = best_result.fdiv(worst_result)
-        end
-        result = sprintf("%.2fx", result)
+        val = result.values.first[1]
+        ratio = val.fdiv(worst_result)
+        result = sprintf("%.2fx", ratio)
       end
       length = [context.name.length, NAME_LENGTH].max
       $stdout.printf("|%*s", length, result)


### PR DESCRIPTION
`-o markdown --output-compare` is broken when measuring metrics are "smaller is better".

smaller is better:

```
% ./exe/benchmark-driver -r memory -o markdown --output-compare -e ~/tmp/r/bin/ruby -e ~/tmp/r2/bin/ruby ~/g/ruby/benchmark/nil_p.yml
# Max resident set size (bytes)

|             |/Users/ani/tmp/r/bin/ruby|/Users/ani/tmp/r2/bin/ruby|
|:------------|------------------------:|-------------------------:|
|xnil.nil?    |                  15.172M|                   14.811M|
|             |                        -
```

larger is better:

```
% ./exe/benchmark-driver -r ips -o markdown --output-compare -e ~/tmp/r/bin/ruby -e ~/tmp/r2/bin/ruby ~/g/ruby/benchmark/nil_p.yml
# Iteration per second (i/s)

|             |/Users/ani/tmp/r/bin/ruby|/Users/ani/tmp/r2/bin/ruby|
|:------------|------------------------:|-------------------------:|
|xnil.nil?    |                  66.424M|                   65.919M|
|             |                    1.01x|                         -|
|notnil.nil?  |                  87.933M|                   86.956M|
|             |                    1.01x|                         -|
|niller.nil?  |                  82.793M|                   87.858M|
|             |                        -|                     1.06x|
```

This pull request fixes the problem.

smaller is better:

```
% ./exe/benchmark-driver -r memory -o markdown --output-compare -e ~/tmp/r/bin/ruby -e ~/tmp/r2/bin/ruby ~/g/ruby/benchmark/nil_p.yml
# Max resident set size (bytes)

|             |/Users/ani/tmp/r/bin/ruby|/Users/ani/tmp/r2/bin/ruby|
|:------------|------------------------:|-------------------------:|
|xnil.nil?    |                  13.992M|                   13.386M|
|             |                        -|                     0.96x|
|notnil.nil?  |                  14.189M|                   14.418M|
|             |                    0.98x|                         -|
|niller.nil?  |                  14.352M|                   14.418M|
|             |                    1.00x|                         -|
```

larger is better:

```
%./exe/benchmark-driver -r ips -o markdown --output-compare -e ~/tmp/r/bin/ruby -e ~/tmp/r2/bin/ruby ~/g/ruby/benchmark/nil_p.yml
# Iteration per second (i/s)

|             |/Users/ani/tmp/r/bin/ruby|/Users/ani/tmp/r2/bin/ruby|
|:------------|------------------------:|-------------------------:|
|xnil.nil?    |                  65.208M|                   66.505M|
|             |                        -|                     1.02x|
|notnil.nil?  |                  87.282M|                   85.851M|
|             |                    1.02x|                         -|
|niller.nil?  |                  86.234M|                   85.801M|
|             |                    1.01x|                         -|
```